### PR TITLE
fix: display voting address validation messages

### DIFF
--- a/src/components/VoteMessage.js
+++ b/src/components/VoteMessage.js
@@ -139,11 +139,9 @@ class VoteMessage extends React.Component {
       return;
     }
 
-    // just warn
-    window.alert('that voting address is not a currently registered');
     this.setState({
       votingAddrMessage: '',
-      votingAddrError: 'that voting address is not a currently registered',
+      votingAddrError: 'That voting address is not currently registered.',
     });
   };
 
@@ -187,14 +185,14 @@ class VoteMessage extends React.Component {
           {this.state.votingAddrMessage.length > 0 && (
             <Message
               success
-              header="Note"
+              visible
               content={this.state.votingAddrMessage}
             />
           )}
           {this.state.votingAddrError.length > 0 && (
             <Message
               error
-              header="Warning"
+              visible
               content={this.state.votingAddrError}
             />
           )}


### PR DESCRIPTION
Is this what you were after?
|invalid|valid|
|---|---|
|![image](https://user-images.githubusercontent.com/72463218/162619097-eae76cfb-9368-443e-bed4-a39d2cd7eb62.png)|![image](https://user-images.githubusercontent.com/72463218/162620368-39334712-2c69-4dee-b787-1e0dfa8973d7.png)|


For some reason the ui library this project is using defaults messages within its forms to `display:none`.
I guess it's expecting the engineer to configure the component with
```js
            <Message
              error
              visible={this.state.votingAddrError.length > 0}
              content={this.state.votingAddrError}
            />
```
I agree with the current approach of 
```js
          {this.state.votingAddrError.length > 0 && (
            <Message ...params  />
          )}
```
as this won't even try to get the component unless there's an error.

Semanitc UI message component:
https://react.semantic-ui.com/collections/message/
![image](https://user-images.githubusercontent.com/72463218/162619176-95dec562-760b-47c8-97d0-f210cb0ca33e.png)
